### PR TITLE
Prevent damage while player is dead

### DIFF
--- a/client/status.lua
+++ b/client/status.lua
@@ -15,7 +15,7 @@ end)
 if Config.damagePedIfLowStatuses.enabled then
 	CreateThread(function()
 		while true do
-			if statuses and not LocalPlayer.state.dead then
+			if PlayerIsLoaded and not PlayerIsDead and statuses then
 				local playerHealth = GetEntityHealth(cache.ped)
 
 				for _, v in pairs(statuses) do

--- a/client/status.lua
+++ b/client/status.lua
@@ -15,7 +15,7 @@ end)
 if Config.damagePedIfLowStatuses.enabled then
 	CreateThread(function()
 		while true do
-			if statuses then
+			if statuses and not LocalPlayer.state.dead then
 				local playerHealth = GetEntityHealth(cache.ped)
 
 				for _, v in pairs(statuses) do


### PR DESCRIPTION
SetEntityHealth() and ApplyDamageToPed() both will continue applying damage even when the player ped has been set invincible by other scripts. PRing change to block ticks if state.dead.

Possibly more inclusive alternative may be to check if the ped is invincible https://docs.fivem.net/natives/?_0xB721981B2B939E07 not sure if this is necessary but currently player will die even with godmode on if they are hungry/thirsty.